### PR TITLE
Add support for compiler options

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ export default {
   format: 'umd',
   plugins: [
     vueTemplateCompiler({
-      include: '**/*.html'
+      include: '**/*.html',
+      compilerOpts: {
+          // See https://www.npmjs.com/package/vue-template-compiler#options
+      }
     }),
     buble()
   ]

--- a/dist/index.js
+++ b/dist/index.js
@@ -16,6 +16,8 @@ function string(opts) {
 	if (!opts.include) {
 		throw Error('include option should be specified');
 	}
+
+	var templateCompilerOpts = opts.compilerOpts || {};
 	
 	var filter = rollupPluginutils.createFilter(opts.include, opts.exclude);
 
@@ -24,7 +26,7 @@ function string(opts) {
 
 		transform: function transform(code, id) {
 			if (filter(id)) {
-				var compiled = compiler.compile(code);
+				var compiled = compiler.compile(code, templateCompilerOpts);
 				return {
 					code: transpileVueTemplate(("module.exports={render:" + (toFunction(compiled.render)) + ",staticRenderFns:[" + (compiled.staticRenderFns.map(toFunction).join(',')) + "]}")).replace('module.exports={', 'export default {'),
 					map: { mappings: '' }

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -12,6 +12,8 @@ function string(opts) {
 	if (!opts.include) {
 		throw Error('include option should be specified');
 	}
+
+	var templateCompilerOpts = opts.compilerOpts || {};
 	
 	var filter = createFilter(opts.include, opts.exclude);
 
@@ -20,7 +22,7 @@ function string(opts) {
 
 		transform: function transform(code, id) {
 			if (filter(id)) {
-				var compiled = compiler.compile(code);
+				var compiled = compiler.compile(code, templateCompilerOpts);
 				return {
 					code: transpileVueTemplate(("module.exports={render:" + (toFunction(compiled.render)) + ",staticRenderFns:[" + (compiled.staticRenderFns.map(toFunction).join(',')) + "]}")).replace('module.exports={', 'export default {'),
 					map: { mappings: '' }

--- a/index.js
+++ b/index.js
@@ -10,6 +10,8 @@ export default function string(opts = {}) {
 	if (!opts.include) {
 		throw Error('include option should be specified');
 	}
+
+	const templateCompilerOpts = opts.compilerOpts || {};
 	
 	const filter = createFilter(opts.include, opts.exclude);
 
@@ -18,7 +20,7 @@ export default function string(opts = {}) {
 
 		transform(code, id) {
 			if (filter(id)) {
-				const compiled = compiler.compile(code);
+				const compiled = compiler.compile(code, templateCompilerOpts);
 				return {
 					code: transpileVueTemplate(`module.exports={render:${toFunction(compiled.render)},staticRenderFns:[${compiled.staticRenderFns.map(toFunction).join(',')}]}`).replace('module.exports={', 'export default {'),
 					map: { mappings: '' }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,13 @@
     "url": "git+https://github.com/fergaldoyle/rollup-plugin-vue-template-compiler.git"
   },
   "author": "fergaldoyle",
+  "contributors": [
+        {
+            "name": "GerkinDev",
+            "email": "agermain@ithoughts.io",
+            "url": "https://ithoughts.io/"
+        }
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/fergaldoyle/rollup-plugin-vue-template-compiler/issues"


### PR DESCRIPTION
This feature give to the user the ability to set the `compilerOpts` object in the plugin's options.